### PR TITLE
Fix some edge cases.

### DIFF
--- a/px-file-upload.html
+++ b/px-file-upload.html
@@ -164,6 +164,8 @@ Custom property | Description | Default
               this.$$('#validation').innerHTML = "Only one file is allowed.";
               this.toggleClass('hidden',false,this.$$('#validation'));
               this.toggleClass('hidden',true,this.$$('#fileList'));
+              this.$.fileInput.value = "";
+              this.files = [];
               return;
             }
             if(this.accept !== "") {
@@ -171,6 +173,8 @@ Custom property | Description | Default
                 this.$$('#validation').innerHTML = "Invalid file type.";
                 this.toggleClass('hidden',false,this.$$('#validation'));
                 this.toggleClass('hidden',true,this.$$('#fileList'));
+                this.$.fileInput.value = "";
+                this.files = [];
                 return;
               }
               else {
@@ -178,6 +182,8 @@ Custom property | Description | Default
                 this.toggleClass('hidden',true,this.$$('#validation'));
                 this.toggleClass('hidden',false,this.$$('#fileList'));
                 this.$.fileInput.files = e.dataTransfer.files;
+                this.$.fileInput.value = "";
+                this.files = [];
                 return;
               }
             }
@@ -190,6 +196,8 @@ Custom property | Description | Default
                   this.$$('#validation').innerHTML = "Invalid file type.";
                   this.toggleClass('hidden',false,this.$$('#validation'));
                   this.toggleClass('hidden',true,this.$$('#fileList'));
+                  this.$.fileInput.value = "";
+                  this.files = [];
                   return;
                 }
               }
@@ -226,15 +234,24 @@ Custom property | Description | Default
      */
     _fileChange: function(e) {
       this.files = this._toArray(e.target.files);
-      if(!this.multiple) {
-        var filesize = this._readableFileSize(this.files[0].size);
-        this.$$('#fileList').innerHTML = this.files[0].name + ' (' + filesize + ')';
+      
+      if (this.files.length === 0) {
+        this.$$('#fileList').innerHTML = 'No file selected';
+        this.toggleClass('hidden',true,this.$$('#fileTable'));
         this.toggleClass('hidden',false,this.$$('#fileList'));
       }
       else {
-        this.toggleClass('hidden',false,this.$$('#fileTable'));
-        this.toggleClass('hidden',true,this.$$('#fileList'));
+        if(!this.multiple) {
+          var filesize = this._readableFileSize(this.files[0].size);
+          this.$$('#fileList').innerHTML = this.files[0].name + ' (' + filesize + ')';
+          this.toggleClass('hidden',false,this.$$('#fileList'));
+        }
+        else {
+          this.toggleClass('hidden',false,this.$$('#fileTable'));
+          this.toggleClass('hidden',true,this.$$('#fileList'));
+        }
       }
+      
       this.toggleClass('hidden',true,this.$$('#validation'));
       this._notifyFilesChanged();
     },


### PR DESCRIPTION
Fixed some edge cases that weren't behaving properly.

In single file select mode. When a valid file is selected by "Choose File" button, then multiple files are dropped onto drop zone which is invalid. The "Only one file is allowed." text showed, but 'files' property still had the original single valid file.

In single file select mode. When a valid file was selected, and then the "Choose File" clicked again but the file dialog canceled. The browser clears the file input elements files array, but the files Polymer property kept the first file. 