### PR TITLE
updated component to add name property to form input element

### DIFF
--- a/px-file-upload.html
+++ b/px-file-upload.html
@@ -50,7 +50,7 @@ Custom property | Description
         </div>
       </template>
       <label id="fileButton" class$="{{_disableUploadButton(disabled)}} btn u-mr--">{{localize('Choose File')}}
-        <input id="fileInput" disabled$="{{disabled}}" type="file" on-change="_fileChange" multiple={{multiple}} accept={{accept}} hidden></input>
+        <input id="fileInput" name={{name}} disabled$="{{disabled}}" type="file" on-change="_fileChange" multiple={{multiple}} accept={{accept}} hidden></input>
       </label>
       <span id="fileList" class="file-upload-fileList">{{localize('No file selected')}}</span>
       <span id="validation" class="file-upload-validation hidden"></span>
@@ -85,6 +85,16 @@ Custom property | Description
        * @default ""
        */
       accept: {
+        type: String,
+        value: ""
+      },
+      /**
+       * The form element name.
+       * @property name
+       * @type String
+       * @default ""
+       */
+      name: {
         type: String,
         value: ""
       },


### PR DESCRIPTION
This addresses:
https://github.com/PredixDev/px-file-upload/issues/18

The px-fileupload control does not work properly in a basic form using a simple form submit button;
The file elements are not actually uploaded from the browser (they are skipped)
Looking into the reason - I see that the px-stylized form element for input (type=file),
leaves the name off the input form element.

Based on the W3C specification - only form elements having a valid "control-name"
are processed for submission (see included reference):

https://www.w3.org/TR/html401/interact/forms.html#successful-controls

# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:

* ## A reference to a related issue (if applicable):

* ## @mentions of the person or team responsible for reviewing proposed changes:

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.