### PR TITLE
Corrected the spliced index in _removeFile

### DIFF
--- a/px-file-upload.html
+++ b/px-file-upload.html
@@ -326,7 +326,7 @@ Custom property | Description
      */
     _removeFile: function(e) {
       if(!this.disabled) {
-        this.splice("files",e.target.id.substring(4),1);
+        this.splice("files",e.model.__data__.index,1);
         if(this.multiple && this.files.length === 0){
           this.toggleClass('hidden',true,this.$$('#fileTable'));
           this.toggleClass('hidden',false,this.$$('#fileList'));


### PR DESCRIPTION
This is to fix an issue with the `_removeFile()` function in `v1.2.3` with the following actual/expected behavior:

Actual Behavior:
- With four items uploaded into the `px-file-upload`, clicking the X icon on the third removed the first in the list.
- With six items uploaded, clicking the X icon on the final item in the list removed the first one.

Expected Behavior:
- When multiple files are uploaded and the X icon is clicked, the file corresponding to that X icon is removed. E.g. if you click the X for the third file in the list, it removes the third file.

The fix was to get the index from `e.model.__data__` when splicing the `files` array, so that the expected index is removed.