### PR TITLE
SelectFile option throws error when second time does not select any file

### DIFF
--- a/px-file-upload.html
+++ b/px-file-upload.html
@@ -262,6 +262,10 @@ Custom property | Description
     _fileChange: function(e) {
       this.debounce('px-file-upload-file-changed-debounce', function() {
         this.set('files', this._toArray(e.target.files))
+                    
+        if (e.target.files[0] === null || e.target.files[0] === undefined) {
+           return;
+        }
 
         // Single file mode
         if(!this.multiple) {


### PR DESCRIPTION
Issue:
With help of px-file-upload, first time select a file via SelectFile option, second time click on SelectFile and do not select any file and hit cancel, there is error in console.
TypeError: Cannot read property 'type' of undefined
        at HTMLElement._isValid (px-file-upload.html:442)

also event trigger updates files count to zero.
